### PR TITLE
npm error Git working directory not clean.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -28,8 +28,6 @@ jobs:
           git config user.name "the Exploratorium"
       - name: Install dependencies
         run: npm ci
-      - name: Remove examples
-        run: rm -rf examples
       - name: Build
         run: npm run build
       - name: Increment version

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -10,7 +10,6 @@ on:
 
 jobs:
   test-project:
-    name: Run unit tests for the project.
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code.


### PR DESCRIPTION
This commit removes the steps for deleting examples from the npm-publish workflows and a redundant job name from the pr-checks workflow.