### PR TITLE
Add .npmignore files to exclude unnecessary files from packages

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,4 @@
+/examples
+/rollup.config.js
+
+**/*.test.js


### PR DESCRIPTION
Created .npmignore files. This ensures that example directories, rollup configuration files, and test files are not included in the published npm packages.